### PR TITLE
Copy explicitely libfreetype

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -9,6 +9,13 @@ script:
   #- pip install --system --ignore-installed --prefix=/usr --root=AppDir taskcoach
   # Install from source
   - python2 setup.py install --prefix=/usr --root=AppDir
+  # Looks like AppImage does not bundle libfreetype, even if it is
+  # explicitely included because it caused trouble with some
+  # software. Of course NOT including it also causes trouble, at least
+  # with Task Coach. I tested this on Ubuntu 16, 18 and 20 and it
+  # seems to work.
+  - mkdir -p AppDir/usr/lib/x86_64-linux-gnu
+  - cp /usr/lib/x86_64-linux-gnu/libfreetype.so.6 AppDir/usr/lib/x86_64-linux-gnu/
 
 AppDir:
   path: ./AppDir


### PR DESCRIPTION
When I test the AppImage built on an Ubuntu 20 system on older versions, there's a problem at launch because of an unresolved symbol in libfreetype. Turns out appimage-builder doesn't bundle freetype because it caused all sorts of trouble. But having the AppImage only work on one Ubuntu version kind of goes against the idea of it all :)

Copying the .so directly seems to work; at least it works for me on Ubuntu 16, 18 and 20. Hackish though.
